### PR TITLE
Add generic issue templates copied from fidesctl

### DIFF
--- a/.github/ISSUE_TEMPLATE/ethyca_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/ethyca_bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Project Bug report
+about: Problems and issues with the project code
+title: ''
+labels: bug
+
+---
+
+### Bug Description
+
+_A description of what the bug is._
+
+#### Steps to Reproduce
+
+1. _Do this..._
+1. _Then This..._
+
+### Expected behavior
+
+_A description of what you expected to happen._
+
+### Screenshots
+
+_If applicable, add screenshots to help explain your problem._
+
+### Environment
+
+* Version:
+* OS:
+* Python Version:
+* Docker Version:
+
+### Additional context
+
+_Add any other context about the problem here._

--- a/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
+++ b/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
@@ -1,0 +1,15 @@
+---
+name: Project Docs Update
+about: Change suggestions for the project docs
+title: ''
+labels: documentation
+
+---
+
+### Docs Update Description
+
+ _Describe what you'd like to see documented, and link the page if applicable_
+
+### Additional context
+
+_Add any other context about the problem here._

--- a/.github/ISSUE_TEMPLATE/ethyca_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/ethyca_feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Project Feature request
+about: Suggest a new feature/enhancement for this project
+title: ''
+labels: enhancement
+
+---
+
+### Is your feature request related to a specific problem?
+
+_A description of what the problem is._
+_Ex. I'm always frustrated when [...]_
+
+### Describe the solution you'd like
+
+_A description of what you want to happen._
+
+### Describe alternatives you've considered, if any
+
+_A description of any alternative solutions or features you've considered._
+
+### Additional context
+
+_Add any other context or screenshots about the feature request here._


### PR DESCRIPTION
These templates are copied from the [fides repo](https://github.com/ethyca/fides/) with some slight wording changes to not be project specific. Any repo within the ethyca org will use these templates as long as it does not define its own templates. 

Follows the approach from this article: https://chromatichq.com/insights/sharing-github-issue-pull-request-templates

